### PR TITLE
Feat/settings dialog #3

### DIFF
--- a/MuSync.pro
+++ b/MuSync.pro
@@ -40,7 +40,8 @@ SOURCES += \
     models/album.cpp \
     models/lyrics.cpp \
     r.cpp \
-    threading/autorefreshapi.cpp
+    threading/autorefreshapi.cpp \
+    ui/dsettings.cpp
 
 HEADERS += \
         mainwindow.h \
@@ -56,11 +57,13 @@ HEADERS += \
     models/album.h \
     models/lyrics.h \
     r.h \
-    threading/autorefreshapi.h
+    threading/autorefreshapi.h \
+    ui/dsettings.h
 
 FORMS += \
         mainwindow.ui \
-    oauth/oauthdialog.ui
+    oauth/oauthdialog.ui \
+    ui/dsettings.ui
 
 # Default rules for deployment.
 qnx: target.path = /tmp/$${TARGET}/bin

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -194,7 +194,7 @@ void MainWindow::onStartupBehaviourChanged(int startupBehaviour) {
 #ifdef QT_DEBUG
 	cout << "MainWindow> Startup behaviour changed: " << startupBehaviour << endl;
 #endif
-	// TODO: Changed something in the system
+	pref->runAppAtStartup(startupBehaviour >= 1);
 }
 
 void MainWindow::onStyleChanged(int style) {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -19,6 +19,18 @@ MainWindow::MainWindow(QWidget *parent) :
 	connect(pref, SIGNAL(startupBehaviourChanged(int)), this, SLOT(onStartupBehaviourChanged(int)));
 	connect(pref, SIGNAL(styleChanged(int)), this, SLOT(onStyleChanged(int)));
 	
+	traySystem = new QSystemTrayIcon(QIcon(R::getMuSyncIcon()), this);
+	connect(traySystem, SIGNAL(activated(QSystemTrayIcon::ActivationReason)), this, SLOT(onTrayClicked(QSystemTrayIcon::ActivationReason)));
+	connect(traySystem, SIGNAL(messageClicked()), this, SLOT(onTrayMessageClicked()));
+	
+	trayMenu = new QMenu(qApp->applicationName(), this);
+	trayMenu->addAction(ui->actionRefresh);
+	trayMenu->addSeparator();
+	trayMenu->addAction(ui->actionExit);
+	
+	traySystem->setContextMenu(trayMenu);
+	traySystem->show();
+	
 	// Change the the name of "File" menu to the application name
 	ui->menuFile->setTitle(qApp->applicationName());
 	
@@ -97,6 +109,15 @@ void MainWindow::changeTitle(Track track) {
 		changeTitle();
 	else
 		changeTitle(track.toString());
+}
+
+void MainWindow::closeEvent(QCloseEvent* event) {
+	if (pref->getCloseButtonMinimized()) {
+		hide();
+		event->ignore();
+	}
+	else
+		event->accept();
 }
 
 void MainWindow::getTrack(Track track) {
@@ -180,6 +201,22 @@ void MainWindow::showEvent(QShowEvent* event) {
 	QMainWindow::showEvent(event);
 	
 	threadAPIs->start();
+}
+
+void MainWindow::onTrayClicked(QSystemTrayIcon::ActivationReason reason) {
+	switch (reason) {
+		case QSystemTrayIcon::DoubleClick:
+		case QSystemTrayIcon::Trigger:
+		case QSystemTrayIcon::MiddleClick:
+			show();
+			break;
+		default:
+			break;
+	}
+}
+
+void MainWindow::onTrayMessageClicked() {
+	// Do something if messages are displayed
 }
 
 void MainWindow::onAPIsConnected() {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -38,7 +38,12 @@ MainWindow::MainWindow(QWidget *parent) :
 	
 	refreshAPIs->moveToThread(threadAPIs);
 	connect(threadAPIs, &QThread::started, refreshAPIs, &AutoRefreshAPI::refresh);
-	connect(threadAPIs, &QThread::finished, [=]() {refreshAPIs->stop(); refreshAPIs->deleteLater();});
+	connect(threadAPIs, &QThread::finished, [=]() {
+		refreshAPIs->stop();
+		delete refreshAPIs;
+		refreshAPIs = nullptr;
+	});
+	
 	connect(ui->actionRefresh, SIGNAL(triggered()), refreshAPIs, SLOT(refresh()));
 	
 	connect(refreshAPIs, SIGNAL(spotifyPlayingTrackFetched(Track)), this, SLOT(getTrack(Track)));
@@ -186,10 +191,16 @@ void MainWindow::onAboutToRefresh() {
 }
 
 void MainWindow::onStartupBehaviourChanged(int startupBehaviour) {
+#ifdef QT_DEBUG
+	cout << "MainWindow> Startup behaviour changed: " << startupBehaviour << endl;
+#endif
 	// TODO: Changed something in the system
 }
 
 void MainWindow::onStyleChanged(int style) {
+#ifdef QT_DEBUG
+	cout << "MainWindow> Style changed: " << style << endl;
+#endif
 	switch (style) {
 		case Preferences::STYLE_DEFAULT:
 			qApp->setStyleSheet("");
@@ -206,7 +217,7 @@ void MainWindow::on_actionRefresh_triggered() {
 }
 
 void MainWindow::on_actionSettings_triggered() {
-    if (dsettings == nullptr)
+	if (dsettings == nullptr)
 		dsettings = new DSettings(this);
 	
 	dsettings->show();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -16,11 +16,15 @@ MainWindow::MainWindow(QWidget *parent) :
 	
 	pref = Preferences::getInstance(this);
 	
+	connect(pref, SIGNAL(startupBehaviourChanged(int)), this, SLOT(onStartupBehaviourChanged(int)));
+	connect(pref, SIGNAL(styleChanged(int)), this, SLOT(onStyleChanged(int)));
+	
 	// Change the the name of "File" menu to the application name
 	ui->menuFile->setTitle(qApp->applicationName());
 	
 	// Add some icons
 	ui->actionRefresh->setIcon(R::getRefresh());
+	ui->actionSettings->setIcon(R::getSettings());
 	ui->actionExit->setIcon(R::getPower());
 	ui->actionOpenTrackOnSpotifyWeb->setIcon(R::getBrowser(R::getSpotifyColor()));
 	ui->actionOpenAlbumOnSpotifyWeb->setIcon(R::getBrowser(R::getSpotifyColor()));
@@ -181,8 +185,31 @@ void MainWindow::onAboutToRefresh() {
 	ui->actionRefresh->setEnabled(false);
 }
 
+void MainWindow::onStartupBehaviourChanged(int startupBehaviour) {
+	// TODO: Changed something in the system
+}
+
+void MainWindow::onStyleChanged(int style) {
+	switch (style) {
+		case Preferences::STYLE_DEFAULT:
+			qApp->setStyleSheet("");
+			break;
+		case Preferences::STYLE_DARK:
+			ui->statusBar->showMessage("Not implemented yet", 5000);
+			pref->setStyle(Preferences::STYLE_DEFAULT);
+			break;
+	}
+}
+
 void MainWindow::on_actionRefresh_triggered() {
     // Refresh function already connecting. UI can be updated from here
+}
+
+void MainWindow::on_actionSettings_triggered() {
+    if (dsettings == nullptr)
+		dsettings = new DSettings(this);
+	
+	dsettings->show();
 }
 
 void MainWindow::on_actionExit_triggered() {

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -6,6 +6,7 @@
 #include <QMainWindow>
 #include <QMessageBox>
 #include <QAction>
+#include <QSystemTrayIcon>
 
 #include "oauth/oauthdialog.h"
 #include "models/qartistlist.h"
@@ -33,6 +34,9 @@ private:
 	void changeTitle(QString title = "");
 	void changeTitle(Track track);
 	
+protected:
+	void closeEvent(QCloseEvent* event) override;
+	
 private slots:
 	void getTrack(Track track);
 	void getLyrics(Lyrics lyrics);
@@ -49,9 +53,13 @@ public slots:
 	void requestCloseBrowser();
 	
 private:
-	void showEvent(QShowEvent* event);
+	void showEvent(QShowEvent* event) override;
 	
 private slots:
+	/* Tray slots*/
+	void onTrayClicked(QSystemTrayIcon::ActivationReason reason);
+	void onTrayMessageClicked();
+	
 	/* API slots */
 	void onAPIsConnected();
 	void onAboutToRefresh();
@@ -60,7 +68,7 @@ private slots:
 	void onStartupBehaviourChanged(int startupBehaviour);
 	void onStyleChanged(int style);
 	
-	/* Menu slots */
+	/* Menu slots */	
 	void on_actionRefresh_triggered();
 	void on_actionSettings_triggered();
 	void on_actionExit_triggered();
@@ -79,6 +87,8 @@ private:
 	Preferences* pref = nullptr;
 	OAuthDialog* webdialog = nullptr;
 	DSettings* dsettings = nullptr;
+	QSystemTrayIcon* traySystem = nullptr;
+	QMenu* trayMenu = nullptr;
 	
 	AutoRefreshAPI* refreshAPIs;
 	QThread* threadAPIs;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -12,6 +12,7 @@
 #include "models/artist.h"
 #include "preferences.h"
 #include "threading/autorefreshapi.h"
+#include "ui/dsettings.h"
 #include "r.h"
 
 using namespace std;
@@ -51,10 +52,17 @@ private:
 	void showEvent(QShowEvent* event);
 	
 private slots:
+	/* API slots */
 	void onAPIsConnected();
 	void onAboutToRefresh();
 	
+	/* Preferences slots */
+	void onStartupBehaviourChanged(int startupBehaviour);
+	void onStyleChanged(int style);
+	
+	/* Menu slots */
 	void on_actionRefresh_triggered();
+	void on_actionSettings_triggered();
 	void on_actionExit_triggered();
 	
 	void on_actionOpenTrackOnSpotifyApp_triggered();
@@ -70,6 +78,7 @@ private:
 	Ui::MainWindow *ui = nullptr;
 	Preferences* pref = nullptr;
 	OAuthDialog* webdialog = nullptr;
+	DSettings* dsettings = nullptr;
 	
 	AutoRefreshAPI* refreshAPIs;
 	QThread* threadAPIs;

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -223,7 +223,7 @@
     <bool>false</bool>
    </property>
    <property name="icon">
-    <iconset theme=":/svg/refresh">
+    <iconset>
      <normalon>:/svg/refresh</normalon>
     </iconset>
    </property>
@@ -233,7 +233,7 @@
   </action>
   <action name="actionExit">
    <property name="icon">
-    <iconset theme=":/svg/power">
+    <iconset>
      <normalon>:/svg/power</normalon>
     </iconset>
    </property>
@@ -243,7 +243,7 @@
   </action>
   <action name="actionOpenTrackOnSpotifyApp">
    <property name="icon">
-    <iconset theme=":/svg/spotify">
+    <iconset>
      <normalon>:/svg/spotify</normalon>
     </iconset>
    </property>
@@ -256,7 +256,7 @@
   </action>
   <action name="actionOpenTrackOnSpotifyWeb">
    <property name="icon">
-    <iconset theme=":/svg/browser">
+    <iconset>
      <normalon>:/svg/browser</normalon>
     </iconset>
    </property>
@@ -269,7 +269,7 @@
   </action>
   <action name="actionOpenAlbumOnSpotifyApp">
    <property name="icon">
-    <iconset theme=":/svg/spotify">
+    <iconset>
      <normalon>:/svg/spotify</normalon>
     </iconset>
    </property>
@@ -282,7 +282,7 @@
   </action>
   <action name="actionOpenAlbumOnSpotifyWeb">
    <property name="icon">
-    <iconset theme=":/svg/browser">
+    <iconset>
      <normalon>:/svg/browser</normalon>
     </iconset>
    </property>
@@ -295,7 +295,7 @@
   </action>
   <action name="actionOpenLyricsOnGenius">
    <property name="icon">
-    <iconset theme=":/svg/genius-cropped">
+    <iconset>
      <normalon>:/svg/genius-cropped</normalon>
     </iconset>
    </property>
@@ -308,7 +308,7 @@
   </action>
   <action name="actionAboutMuSync">
    <property name="icon">
-    <iconset theme=":/svg/musync">
+    <iconset>
      <normalon>:/svg/musync</normalon>
     </iconset>
    </property>
@@ -318,7 +318,7 @@
   </action>
   <action name="actionAboutQt">
    <property name="icon">
-    <iconset theme=":/svg/qt">
+    <iconset>
      <normalon>:/svg/qt</normalon>
     </iconset>
    </property>
@@ -328,7 +328,7 @@
   </action>
   <action name="actionSettings">
    <property name="icon">
-    <iconset theme=":/svg/settings">
+    <iconset>
      <normalon>:/svg/settings</normalon>
     </iconset>
    </property>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -146,6 +146,7 @@
      <string>File</string>
     </property>
     <addaction name="actionRefresh"/>
+    <addaction name="actionSettings"/>
     <addaction name="separator"/>
     <addaction name="actionExit"/>
    </widget>
@@ -323,6 +324,16 @@
    </property>
    <property name="text">
     <string>About Qt...</string>
+   </property>
+  </action>
+  <action name="actionSettings">
+   <property name="icon">
+    <iconset theme=":/svg/settings">
+     <normalon>:/svg/settings</normalon>
+    </iconset>
+   </property>
+   <property name="text">
+    <string>Settings</string>
    </property>
   </action>
  </widget>

--- a/preferences.cpp
+++ b/preferences.cpp
@@ -5,6 +5,9 @@ Preferences* Preferences::pref;
 Preferences::Preferences(QObject *parent) : QObject(parent) {
 	if (!isFirstLaunch()) {
 		// Init
+		initStartupBehaviour();
+		initCloseButtonMinimized();
+		initStyle();
 		initRefreshTimeout();
 	
 		// Last
@@ -33,10 +36,10 @@ void Preferences::initFirstLaunch() {
 }
 
 int Preferences::getStartupBehavior() {
-	bool success = false;
-	int startupBehaviour = settings.value("app/startupBehaviour", DONT_OPEN_AT_STARTUP).toInt(&success);
+	bool ok = false;
+	int startupBehaviour = settings.value("app/startupBehaviour", defaultStartupBehaviour()).toInt(&ok);
 	
-	if (success && startupBehaviour >= 0 && startupBehaviour <= 2)
+	if (ok && isStartupBehaviourValid(startupBehaviour))
 		return startupBehaviour;
 	else {
 		initStartupBehaviour();
@@ -45,18 +48,26 @@ int Preferences::getStartupBehavior() {
 }
 
 void Preferences::setStartupBehaviour(const int& startupBehaviour) {
-	if (startupBehaviour >= 0 && startupBehaviour <= 2) {
+	if (isStartupBehaviourValid(startupBehaviour)) {
 		settings.setValue("app/startupBehaviour", startupBehaviour);
 		emit startupBehaviourChanged(startupBehaviour);
 	}
 }
 
-void Preferences::initStartupBehaviour() {
-	setStartupBehaviour(DONT_OPEN_AT_STARTUP);
+int Preferences::defaultStartupBehaviour() {
+	return DONT_OPEN_AT_STARTUP;
 }
 
-bool Preferences::doesCloseButtonMinimized() {
-	return settings.value("app/closeButtonMinimized", false).toBool();
+void Preferences::initStartupBehaviour() {
+	setStartupBehaviour(defaultStartupBehaviour());
+}
+
+bool Preferences::isStartupBehaviourValid(const int& startupBehaviour) {
+	return startupBehaviour >= 0 && startupBehaviour <= 2;
+}
+
+bool Preferences::getCloseButtonMinimized() {
+	return settings.value("app/closeButtonMinimized", defaultCloseButtonMinimized()).toBool();
 }
 
 void Preferences::setCloseButtonMinimized(const bool& closeButtonMinimized) {
@@ -64,15 +75,19 @@ void Preferences::setCloseButtonMinimized(const bool& closeButtonMinimized) {
 	emit closeButtonMinimizedChanged(closeButtonMinimized);
 }
 
+bool Preferences::defaultCloseButtonMinimized() {
+	return false;
+}
+
 void Preferences::initCloseButtonMinimized() {
-	setCloseButtonMinimized(false);
+	setCloseButtonMinimized(defaultCloseButtonMinimized());
 }
 
 int Preferences::getStyle() {
-	bool success = false;
-	int style = settings.value("view/style", STYLE_DEFAULT).toInt(&success);
+	bool ok = false;
+	int style = settings.value("view/style", defaultStyle()).toInt(&ok);
 	
-	if (success && style >= 0 && style <= 1)
+	if (ok && isStyleValid(style))
 		return style;
 	else {
 		initStyle();
@@ -80,22 +95,30 @@ int Preferences::getStyle() {
 	}
 }
 
-void Preferences::setStyle(int style) {
-	if (style >= 0 && style <= 1) {
+void Preferences::setStyle(const int& style) {
+	if (isStyleValid(style)) {
 		settings.setValue("view/style", style);
 		emit styleChanged(style);
 	}
 }
 
+int Preferences::defaultStyle() {
+	return STYLE_DEFAULT;
+}
+
 void Preferences::initStyle() {
-	setStyle(STYLE_DEFAULT);
+	setStyle(defaultStyle());
+}
+
+bool Preferences::isStyleValid(const int& style) {
+	return 0 <= style && style <= 1;
 }
 
 int Preferences::getRefreshTimeout() {
 	bool ok = false;
-	int refreshTimeout = settings.value("network/refreshTimeout", 0).toInt(&ok);
+	int refreshTimeout = settings.value("network/refreshTimeout", defaultRefreshTimeout()).toInt(&ok);
 	
-	if (ok && 1000 <= refreshTimeout && refreshTimeout <= 3600000)
+	if (ok && 1000 <= isRefreshTimeoutValid(refreshTimeout))
 		return refreshTimeout;
 	else {
 		initRefreshTimeout();
@@ -104,14 +127,22 @@ int Preferences::getRefreshTimeout() {
 }
 
 void Preferences::setRefreshTimeout(const int& refreshTimeout) {
-	if (1000 <= refreshTimeout && refreshTimeout <= 3600000) {
+	if (isRefreshTimeoutValid(refreshTimeout)) {
 		settings.setValue("network/refreshTimeout", refreshTimeout);
 		emit refreshTimeoutChanged(refreshTimeout);
 	}
 }
 
+int Preferences::defaultRefreshTimeout() {
+	return 5000; // 5s
+}
+
 void Preferences::initRefreshTimeout() {
-	setRefreshTimeout(5000); // 5s
+	setRefreshTimeout(defaultRefreshTimeout());
+}
+
+bool Preferences::isRefreshTimeoutValid(const int& refreshTimeout) {
+	return 1000 <= refreshTimeout && refreshTimeout <= 3600000;
 }
 
 void Preferences::clear() {

--- a/preferences.cpp
+++ b/preferences.cpp
@@ -45,8 +45,10 @@ int Preferences::getStartupBehavior() {
 }
 
 void Preferences::setStartupBehaviour(const int& startupBehaviour) {
-	settings.setValue("app/startupBehaviour", startupBehaviour);
-	emit startupBehaviourChanged(startupBehaviour);
+	if (startupBehaviour >= 0 && startupBehaviour <= 2) {
+		settings.setValue("app/startupBehaviour", startupBehaviour);
+		emit startupBehaviourChanged(startupBehaviour);
+	}
 }
 
 void Preferences::initStartupBehaviour() {
@@ -79,8 +81,10 @@ int Preferences::getStyle() {
 }
 
 void Preferences::setStyle(int style) {
-	settings.setValue("view/style", style);
-	emit styleChanged(style);
+	if (style >= 0 && style <= 1) {
+		settings.setValue("view/style", style);
+		emit styleChanged(style);
+	}
 }
 
 void Preferences::initStyle() {
@@ -91,7 +95,7 @@ int Preferences::getRefreshTimeout() {
 	bool ok = false;
 	int refreshTimeout = settings.value("network/refreshTimeout", 0).toInt(&ok);
 	
-	if (ok && refreshTimeout >= 1000)
+	if (ok && 1000 <= refreshTimeout && refreshTimeout <= 3600000)
 		return refreshTimeout;
 	else {
 		initRefreshTimeout();
@@ -100,7 +104,7 @@ int Preferences::getRefreshTimeout() {
 }
 
 void Preferences::setRefreshTimeout(const int& refreshTimeout) {
-	if (refreshTimeout >= 1000) {
+	if (1000 <= refreshTimeout && refreshTimeout <= 3600000) {
 		settings.setValue("network/refreshTimeout", refreshTimeout);
 		emit refreshTimeoutChanged(refreshTimeout);
 	}
@@ -108,4 +112,8 @@ void Preferences::setRefreshTimeout(const int& refreshTimeout) {
 
 void Preferences::initRefreshTimeout() {
 	setRefreshTimeout(5000); // 5s
+}
+
+void Preferences::clear() {
+	settings.clear();
 }

--- a/preferences.cpp
+++ b/preferences.cpp
@@ -23,7 +23,7 @@ Preferences* Preferences::getInstance(QObject* parent) {
 }
 
 bool Preferences::isFirstLaunch() {
-	return settings.value("app/firstLaunch", false).toBool();
+	return settings.value("app/firstLaunch", defaultFirstLaunch()).toBool();
 }
 
 void Preferences::setFirstLaunch(const bool& firstLaunch) {
@@ -31,8 +31,12 @@ void Preferences::setFirstLaunch(const bool& firstLaunch) {
 	emit firstLaunchChanged(firstLaunch);
 }
 
+bool Preferences::defaultFirstLaunch() {
+	return true;
+}
+
 void Preferences::initFirstLaunch() {
-	setFirstLaunch(true);
+	setFirstLaunch(defaultFirstLaunch());
 }
 
 int Preferences::getStartupBehavior() {
@@ -118,7 +122,7 @@ int Preferences::getRefreshTimeout() {
 	bool ok = false;
 	int refreshTimeout = settings.value("network/refreshTimeout", defaultRefreshTimeout()).toInt(&ok);
 	
-	if (ok && 1000 <= isRefreshTimeoutValid(refreshTimeout))
+	if (ok && isRefreshTimeoutValid(refreshTimeout))
 		return refreshTimeout;
 	else {
 		initRefreshTimeout();

--- a/preferences.cpp
+++ b/preferences.cpp
@@ -15,7 +15,7 @@ Preferences::Preferences(QObject *parent) : QObject(parent) {
 Preferences* Preferences::getInstance(QObject* parent) {
 	if (Preferences::pref == nullptr)
 		Preferences::pref = new Preferences(parent);
-
+	
 	return Preferences::pref;
 }
 
@@ -23,7 +23,7 @@ bool Preferences::isFirstLaunch() {
 	return settings.value("app/firstLaunch", false).toBool();
 }
 
-void Preferences::setFirstLaunch(bool firstLaunch) {
+void Preferences::setFirstLaunch(const bool& firstLaunch) {
 	settings.setValue("app/firstLaunch", firstLaunch);
 	emit firstLaunchChanged(firstLaunch);
 }
@@ -32,20 +32,74 @@ void Preferences::initFirstLaunch() {
 	setFirstLaunch(true);
 }
 
+int Preferences::getStartupBehavior() {
+	bool success = false;
+	int startupBehaviour = settings.value("app/startupBehaviour", DONT_OPEN_AT_STARTUP).toInt(&success);
+	
+	if (success && startupBehaviour >= 0 && startupBehaviour <= 2)
+		return startupBehaviour;
+	else {
+		initStartupBehaviour();
+		return getStartupBehavior();
+	}
+}
+
+void Preferences::setStartupBehaviour(const int& startupBehaviour) {
+	settings.setValue("app/startupBehaviour", startupBehaviour);
+	emit startupBehaviourChanged(startupBehaviour);
+}
+
+void Preferences::initStartupBehaviour() {
+	setStartupBehaviour(DONT_OPEN_AT_STARTUP);
+}
+
+bool Preferences::doesCloseButtonMinimized() {
+	return settings.value("app/closeButtonMinimized", false).toBool();
+}
+
+void Preferences::setCloseButtonMinimized(const bool& closeButtonMinimized) {
+	settings.setValue("app/closeButtonMinimized", closeButtonMinimized);
+	emit closeButtonMinimizedChanged(closeButtonMinimized);
+}
+
+void Preferences::initCloseButtonMinimized() {
+	setCloseButtonMinimized(false);
+}
+
+int Preferences::getStyle() {
+	bool success = false;
+	int style = settings.value("view/style", STYLE_DEFAULT).toInt(&success);
+	
+	if (success && style >= 0 && style <= 1)
+		return style;
+	else {
+		initStyle();
+		return getStyle();
+	}
+}
+
+void Preferences::setStyle(int style) {
+	settings.setValue("view/style", style);
+	emit styleChanged(style);
+}
+
+void Preferences::initStyle() {
+	setStyle(STYLE_DEFAULT);
+}
+
 int Preferences::getRefreshTimeout() {
 	bool ok = false;
 	int refreshTimeout = settings.value("network/refreshTimeout", 0).toInt(&ok);
 	
-	if (ok && refreshTimeout >= 1000) {
+	if (ok && refreshTimeout >= 1000)
 		return refreshTimeout;
-	}
 	else {
 		initRefreshTimeout();
 		return getRefreshTimeout();
 	}
 }
 
-void Preferences::setRefreshTimeout(int refreshTimeout) {
+void Preferences::setRefreshTimeout(const int& refreshTimeout) {
 	if (refreshTimeout >= 1000) {
 		settings.setValue("network/refreshTimeout", refreshTimeout);
 		emit refreshTimeoutChanged(refreshTimeout);

--- a/preferences.cpp
+++ b/preferences.cpp
@@ -149,6 +149,17 @@ bool Preferences::isRefreshTimeoutValid(const int& refreshTimeout) {
 	return 1000 <= refreshTimeout && refreshTimeout <= 3600000;
 }
 
+void Preferences::runAppAtStartup(bool runAtStartup) {
+	QSettings runSettings("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Run",
+						  QSettings::NativeFormat);
+	if (runAtStartup) {
+		runSettings.setValue(qApp->applicationName(),
+							 QCoreApplication::applicationFilePath().replace('/', '\\'));
+	}
+	else
+		runSettings.remove(qApp->applicationName());
+}
+
 void Preferences::clear() {
 	settings.clear();
 }

--- a/preferences.h
+++ b/preferences.h
@@ -14,15 +14,37 @@ public:
 	static Preferences* getInstance(QObject* parent = nullptr);
 	
 	bool isFirstLaunch();
-	void setFirstLaunch(bool firstLaunch = true);
+	void setFirstLaunch(const bool& firstLaunch = true);
 	void initFirstLaunch();
 	
+	int getStartupBehavior();
+	void setStartupBehaviour(const int& startupBehaviour);
+	void initStartupBehaviour();
+	
+	bool doesCloseButtonMinimized();
+	void setCloseButtonMinimized(const bool& closeButtonMinimized);
+	void initCloseButtonMinimized();
+	
+	int getStyle();
+	void setStyle(int style);
+	void initStyle();
+	
 	int getRefreshTimeout();
-	void setRefreshTimeout(int refreshTimeout);
+	void setRefreshTimeout(const int& refreshTimeout);
 	void initRefreshTimeout();
+	
+	static const int DONT_OPEN_AT_STARTUP = 0;
+	static const int OPEN_AT_STARTUP = 1;
+	static const int OPEN_AT_STARTUP_MINIMIZED = 2;
+	
+	static const int STYLE_DEFAULT = 0;
+	static const int STYLE_DARK = 1;
 	
 signals:
 	void firstLaunchChanged(bool);
+	void startupBehaviourChanged(int);
+	void closeButtonMinimizedChanged(bool);
+	void styleChanged(int);
 	void refreshTimeoutChanged(int);
 	
 private:

--- a/preferences.h
+++ b/preferences.h
@@ -4,6 +4,8 @@
 #include <iostream>
 #include <QObject>
 #include <QSettings>
+#include <QApplication>
+
 
 using namespace std;
 
@@ -40,6 +42,8 @@ public:
 	int defaultRefreshTimeout();
 	void initRefreshTimeout();
 	bool isRefreshTimeoutValid(const int& refreshTimeout);
+	
+	void runAppAtStartup(bool runAtStartup);
 	
 	void clear();
 	

--- a/preferences.h
+++ b/preferences.h
@@ -15,6 +15,7 @@ public:
 	
 	bool isFirstLaunch();
 	void setFirstLaunch(const bool& firstLaunch = true);
+	bool defaultFirstLaunch();
 	void initFirstLaunch();
 	
 	int getStartupBehavior();

--- a/preferences.h
+++ b/preferences.h
@@ -33,6 +33,8 @@ public:
 	void setRefreshTimeout(const int& refreshTimeout);
 	void initRefreshTimeout();
 	
+	void clear();
+	
 	static const int DONT_OPEN_AT_STARTUP = 0;
 	static const int OPEN_AT_STARTUP = 1;
 	static const int OPEN_AT_STARTUP_MINIMIZED = 2;

--- a/preferences.h
+++ b/preferences.h
@@ -19,19 +19,26 @@ public:
 	
 	int getStartupBehavior();
 	void setStartupBehaviour(const int& startupBehaviour);
+	int defaultStartupBehaviour();
 	void initStartupBehaviour();
+	bool isStartupBehaviourValid(const int& startupBehaviour);
 	
-	bool doesCloseButtonMinimized();
+	bool getCloseButtonMinimized();
 	void setCloseButtonMinimized(const bool& closeButtonMinimized);
+	bool defaultCloseButtonMinimized();
 	void initCloseButtonMinimized();
 	
 	int getStyle();
-	void setStyle(int style);
+	void setStyle(const int& style);
+	int defaultStyle();
 	void initStyle();
+	bool isStyleValid(const int& style);
 	
 	int getRefreshTimeout();
 	void setRefreshTimeout(const int& refreshTimeout);
+	int defaultRefreshTimeout();
 	void initRefreshTimeout();
+	bool isRefreshTimeoutValid(const int& refreshTimeout);
 	
 	void clear();
 	

--- a/ui/dsettings.cpp
+++ b/ui/dsettings.cpp
@@ -7,10 +7,39 @@ DSettings::DSettings(QWidget *parent) :
 	ui->setupUi(this);
 	
 	pref = Preferences::getInstance(this);
+	
+	onStartupBehaviourChanged(pref->getStartupBehavior());
+	onCloseButtonMinimizedChanged(pref->getCloseButtonMinimized());
+	onStyleChanged(pref->getStyle());
+	onRefreshTimeoutChanged(pref->getRefreshTimeout());
+	
+	connect(pref, SIGNAL(startupBehaviourChanged(int)), this, SLOT(onStartupBehaviourChanged(int)));
+	connect(pref, SIGNAL(closeButtonMinimizedChanged(bool)), this, SLOT(onCloseButtonMinimizedChanged(bool)));
+	connect(pref, SIGNAL(styleChanged(int)), this, SLOT(onStyleChanged(int)));
+	connect(pref, SIGNAL(refreshTimeoutChanged(int)), this, SLOT(onRefreshTimeoutChanged(int)));
 }
 
 DSettings::~DSettings() {
 	delete ui;
+}
+
+void DSettings::onStartupBehaviourChanged(int startupBehaviour) {
+	if (pref->isStartupBehaviourValid(startupBehaviour))
+		ui->cb_startupBehaviour->setCurrentIndex(startupBehaviour);
+}
+
+void DSettings::onCloseButtonMinimizedChanged(bool closeButtonMinimized) {
+	ui->cb_closeMinimizesApp->setCheckState(closeButtonMinimized ? Qt::Checked : Qt::Unchecked);
+}
+
+void DSettings::onStyleChanged(int style) {
+	if (pref->isStyleValid(style))
+		ui->cb_style->setCurrentIndex(style);
+}
+
+void DSettings::onRefreshTimeoutChanged(int refreshTimeout) {
+	if (pref->isRefreshTimeoutValid(refreshTimeout))
+		ui->sb_refreshTimeout->setValue(refreshTimeout/1000);
 }
 
 void DSettings::on_cb_startupBehaviour_currentIndexChanged(int index) {

--- a/ui/dsettings.cpp
+++ b/ui/dsettings.cpp
@@ -14,30 +14,38 @@ DSettings::~DSettings() {
 }
 
 void DSettings::on_cb_startupBehaviour_currentIndexChanged(int index) {
-    //
+    pref->setStartupBehaviour(index);
 }
 
 void DSettings::on_cb_closeMinimizesApp_stateChanged(int check) {
 	switch (check) {
 		case Qt::Checked:
-			//
+			pref->setCloseButtonMinimized(true);
 			break;
 		case Qt::Unchecked:
-			//
+			pref->setCloseButtonMinimized(false);
 			break;
 		default: // Qt::PartiallyChecked
+			ui->cb_closeMinimizesApp->setCheckState(Qt::Unchecked);
 			break;
 	}
 }
 
 void DSettings::on_cb_style_currentIndexChanged(int index) {
-    //
+    pref->setStyle(index);
 }
 
 void DSettings::on_sb_refreshTimeout_valueChanged(int timeout_s) {
-    //
+    pref->setRefreshTimeout(timeout_s * 1000);
 }
 
 void DSettings::on_pb_resetSettings_clicked() {
-    //
+    int answer = QMessageBox::question(this, "Clear all settings", "Are you sure you want to clear all the settings of the application? This include the credentials for the APIs Spotify and Genius.");
+	
+	if (answer == QMessageBox::Yes) {
+#ifdef QT_DEBUG
+		cout << "DSettings> Clearing all settings" << endl;
+#endif
+		pref->clear();
+	}
 }

--- a/ui/dsettings.cpp
+++ b/ui/dsettings.cpp
@@ -12,11 +12,6 @@ DSettings::DSettings(QWidget *parent) :
 	onCloseButtonMinimizedChanged(pref->getCloseButtonMinimized());
 	onStyleChanged(pref->getStyle());
 	onRefreshTimeoutChanged(pref->getRefreshTimeout());
-	
-	connect(pref, SIGNAL(startupBehaviourChanged(int)), this, SLOT(onStartupBehaviourChanged(int)));
-	connect(pref, SIGNAL(closeButtonMinimizedChanged(bool)), this, SLOT(onCloseButtonMinimizedChanged(bool)));
-	connect(pref, SIGNAL(styleChanged(int)), this, SLOT(onStyleChanged(int)));
-	connect(pref, SIGNAL(refreshTimeoutChanged(int)), this, SLOT(onRefreshTimeoutChanged(int)));
 }
 
 DSettings::~DSettings() {
@@ -24,22 +19,36 @@ DSettings::~DSettings() {
 }
 
 void DSettings::onStartupBehaviourChanged(int startupBehaviour) {
-	if (pref->isStartupBehaviourValid(startupBehaviour))
+	if (pref->isStartupBehaviourValid(startupBehaviour)) {
+		disconnect(pref, SIGNAL(startupBehaviourChanged(int)), this, SLOT(onStartupBehaviourChanged(int)));
 		ui->cb_startupBehaviour->setCurrentIndex(startupBehaviour);
+		connect(pref, SIGNAL(startupBehaviourChanged(int)), this, SLOT(onStartupBehaviourChanged(int)));
+	}
 }
 
 void DSettings::onCloseButtonMinimizedChanged(bool closeButtonMinimized) {
+	disconnect(pref, SIGNAL(closeButtonMinimizedChanged(bool)), this, SLOT(onCloseButtonMinimizedChanged(bool)));
 	ui->cb_closeMinimizesApp->setCheckState(closeButtonMinimized ? Qt::Checked : Qt::Unchecked);
+	connect(pref, SIGNAL(closeButtonMinimizedChanged(bool)), this, SLOT(onCloseButtonMinimizedChanged(bool)));
 }
 
 void DSettings::onStyleChanged(int style) {
-	if (pref->isStyleValid(style))
+	if (pref->isStyleValid(style)) {
+#ifdef QT_DEBUG
+		cout << "DSettings> Style changed: " << style << " (" << ui->cb_style->itemText(style).toStdString() << ")" << endl;
+#endif
+		disconnect(pref, SIGNAL(styleChanged(int)), this, SLOT(onStyleChanged(int)));
 		ui->cb_style->setCurrentIndex(style);
+		connect(pref, SIGNAL(styleChanged(int)), this, SLOT(onStyleChanged(int)));
+	}
 }
 
 void DSettings::onRefreshTimeoutChanged(int refreshTimeout) {
-	if (pref->isRefreshTimeoutValid(refreshTimeout))
+	if (pref->isRefreshTimeoutValid(refreshTimeout)) {
+		disconnect(pref, SIGNAL(refreshTimeoutChanged(int)), this, SLOT(onRefreshTimeoutChanged(int)));
 		ui->sb_refreshTimeout->setValue(refreshTimeout/1000);
+		connect(pref, SIGNAL(refreshTimeoutChanged(int)), this, SLOT(onRefreshTimeoutChanged(int)));
+	}
 }
 
 void DSettings::on_cb_startupBehaviour_currentIndexChanged(int index) {
@@ -61,6 +70,9 @@ void DSettings::on_cb_closeMinimizesApp_stateChanged(int check) {
 }
 
 void DSettings::on_cb_style_currentIndexChanged(int index) {
+#ifdef QT_DEBUG
+	cout << "DSettings> Style has been set to " << index << " (" << ui->cb_style->itemText(index).toStdString() << ")" << endl;
+#endif
     pref->setStyle(index);
 }
 

--- a/ui/dsettings.cpp
+++ b/ui/dsettings.cpp
@@ -13,12 +13,12 @@ DSettings::~DSettings() {
 	delete ui;
 }
 
-void DSettings::on_cb_startupBehavior_currentIndexChanged(const QString &arg1) {
+void DSettings::on_cb_startupBehaviour_currentIndexChanged(int index) {
     //
 }
 
-void DSettings::on_cb_closeMinimizesApp_stateChanged(int arg1) {
-	switch (arg1) {
+void DSettings::on_cb_closeMinimizesApp_stateChanged(int check) {
+	switch (check) {
 		case Qt::Checked:
 			//
 			break;
@@ -30,11 +30,11 @@ void DSettings::on_cb_closeMinimizesApp_stateChanged(int arg1) {
 	}
 }
 
-void DSettings::on_cb_style_currentIndexChanged(const QString &arg1) {
+void DSettings::on_cb_style_currentIndexChanged(int index) {
     //
 }
 
-void DSettings::on_sb_refreshTimeout_valueChanged(int arg1) {
+void DSettings::on_sb_refreshTimeout_valueChanged(int timeout_s) {
     //
 }
 

--- a/ui/dsettings.cpp
+++ b/ui/dsettings.cpp
@@ -1,0 +1,43 @@
+#include "dsettings.h"
+#include "ui_dsettings.h"
+
+DSettings::DSettings(QWidget *parent) :
+	QDialog(parent),
+	ui(new Ui::DSettings) {
+	ui->setupUi(this);
+	
+	pref = Preferences::getInstance(this);
+}
+
+DSettings::~DSettings() {
+	delete ui;
+}
+
+void DSettings::on_cb_startupBehavior_currentIndexChanged(const QString &arg1) {
+    //
+}
+
+void DSettings::on_cb_closeMinimizesApp_stateChanged(int arg1) {
+	switch (arg1) {
+		case Qt::Checked:
+			//
+			break;
+		case Qt::Unchecked:
+			//
+			break;
+		default: // Qt::PartiallyChecked
+			break;
+	}
+}
+
+void DSettings::on_cb_style_currentIndexChanged(const QString &arg1) {
+    //
+}
+
+void DSettings::on_sb_refreshTimeout_valueChanged(int arg1) {
+    //
+}
+
+void DSettings::on_pb_resetSettings_clicked() {
+    //
+}

--- a/ui/dsettings.h
+++ b/ui/dsettings.h
@@ -1,0 +1,36 @@
+#ifndef DSETTINGS_H
+#define DSETTINGS_H
+
+#include <iostream>
+#include <QDialog>
+#include <QMessageBox>
+
+#include "preferences.h"
+
+using namespace std;
+
+namespace Ui {
+	class DSettings;
+}
+
+class DSettings : public QDialog
+{
+	Q_OBJECT
+	
+public:
+	explicit DSettings(QWidget *parent = nullptr);
+	~DSettings();
+	
+private slots:
+	void on_cb_startupBehavior_currentIndexChanged(const QString &arg1);
+	void on_cb_closeMinimizesApp_stateChanged(int arg1);
+	void on_cb_style_currentIndexChanged(const QString &arg1);
+	void on_sb_refreshTimeout_valueChanged(int arg1);
+	void on_pb_resetSettings_clicked();
+	
+private:
+	Ui::DSettings *ui;
+	Preferences* pref;
+};
+
+#endif // DSETTINGS_H

--- a/ui/dsettings.h
+++ b/ui/dsettings.h
@@ -22,6 +22,13 @@ public:
 	~DSettings();
 	
 private slots:
+	/* Preferences slots */
+	void onStartupBehaviourChanged(int startupBehaviour);
+	void onCloseButtonMinimizedChanged(bool closeButtonMinimized);
+	void onStyleChanged(int style);
+	void onRefreshTimeoutChanged(int refreshTimeout);
+	
+	/* Menu slots */
 	void on_cb_startupBehaviour_currentIndexChanged(int index);
 	void on_cb_closeMinimizesApp_stateChanged(int check);
 	void on_cb_style_currentIndexChanged(int index);

--- a/ui/dsettings.h
+++ b/ui/dsettings.h
@@ -22,10 +22,10 @@ public:
 	~DSettings();
 	
 private slots:
-	void on_cb_startupBehavior_currentIndexChanged(const QString &arg1);
-	void on_cb_closeMinimizesApp_stateChanged(int arg1);
-	void on_cb_style_currentIndexChanged(const QString &arg1);
-	void on_sb_refreshTimeout_valueChanged(int arg1);
+	void on_cb_startupBehaviour_currentIndexChanged(int index);
+	void on_cb_closeMinimizesApp_stateChanged(int check);
+	void on_cb_style_currentIndexChanged(int index);
+	void on_sb_refreshTimeout_valueChanged(int timeout_s);
 	void on_pb_resetSettings_clicked();
 	
 private:

--- a/ui/dsettings.ui
+++ b/ui/dsettings.ui
@@ -13,6 +13,9 @@
   <property name="windowTitle">
    <string>Dialog</string>
   </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QTabWidget" name="tabWidget">

--- a/ui/dsettings.ui
+++ b/ui/dsettings.ui
@@ -1,0 +1,690 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DSettings</class>
+ <widget class="QDialog" name="DSettings">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>2</number>
+     </property>
+     <widget class="QWidget" name="tabApp">
+      <attribute name="title">
+       <string>App</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QScrollArea" name="scrollArea">
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="scrollAreaWidgetContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>350</width>
+            <height>221</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_3">
+           <item>
+            <widget class="QGroupBox" name="groupBox">
+             <property name="title">
+              <string>Behavior</string>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_4">
+              <item>
+               <widget class="QWidget" name="widget" native="true">
+                <layout class="QHBoxLayout" name="horizontalLayout">
+                 <item>
+                  <widget class="QLabel" name="label">
+                   <property name="text">
+                    <string>Open MuSync on startup</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QComboBox" name="cb_startupBehavior">
+                   <item>
+                    <property name="text">
+                     <string>No</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>Yes</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>Yes but minimized</string>
+                    </property>
+                   </item>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="cb_closeMinimizesApp">
+                <property name="text">
+                 <string>Close button minimizes MuSync</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabView">
+      <attribute name="title">
+       <string>View</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_5">
+       <item>
+        <widget class="QScrollArea" name="scrollArea_2">
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="scrollAreaWidgetContents_2">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>350</width>
+            <height>221</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_7">
+           <item>
+            <widget class="QGroupBox" name="groupBox_2">
+             <property name="title">
+              <string>Theme</string>
+             </property>
+             <layout class="QHBoxLayout" name="horizontalLayout_2">
+              <item>
+               <widget class="QLabel" name="label_2">
+                <property name="text">
+                 <string>Choose a style</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QComboBox" name="cb_style">
+                <item>
+                 <property name="text">
+                  <string>Default</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Dark</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabAdvanced">
+      <attribute name="title">
+       <string>Advanced</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_6">
+       <item>
+        <widget class="QScrollArea" name="scrollArea_3">
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="scrollAreaWidgetContents_3">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>350</width>
+            <height>221</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_8">
+           <item>
+            <widget class="QGroupBox" name="groupBox_3">
+             <property name="title">
+              <string>Auto Refresh</string>
+             </property>
+             <layout class="QHBoxLayout" name="horizontalLayout_3">
+              <item>
+               <widget class="QLabel" name="label_3">
+                <property name="text">
+                 <string>Refresh the lyrics every</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="sb_refreshTimeout">
+                <property name="accelerated">
+                 <bool>true</bool>
+                </property>
+                <property name="suffix">
+                 <string>s</string>
+                </property>
+                <property name="minimum">
+                 <number>1</number>
+                </property>
+                <property name="maximum">
+                 <number>3600</number>
+                </property>
+                <property name="value">
+                 <number>5</number>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QGroupBox" name="groupBox_4">
+             <property name="title">
+              <string>Danger Zone</string>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_9">
+              <item>
+               <widget class="QPushButton" name="pb_resetSettings">
+                <property name="palette">
+                 <palette>
+                  <active>
+                   <colorrole role="WindowText">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>0</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Button">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>170</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Midlight">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>212</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Dark">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>85</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Mid">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>113</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Text">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>255</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="BrightText">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>255</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="ButtonText">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>255</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Base">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>255</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Window">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>170</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Shadow">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>0</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="AlternateBase">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>212</red>
+                      <green>127</green>
+                      <blue>127</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="ToolTipBase">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>220</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="ToolTipText">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>0</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="PlaceholderText">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="128">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>255</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </active>
+                  <inactive>
+                   <colorrole role="WindowText">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>0</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Button">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>170</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Midlight">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>212</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Dark">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>85</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Mid">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>113</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Text">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>255</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="BrightText">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>255</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="ButtonText">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>255</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Base">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>255</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Window">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>170</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Shadow">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>0</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="AlternateBase">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>212</red>
+                      <green>127</green>
+                      <blue>127</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="ToolTipBase">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>220</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="ToolTipText">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>0</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="PlaceholderText">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="128">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>255</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </inactive>
+                  <disabled>
+                   <colorrole role="WindowText">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>85</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Button">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>170</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Midlight">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>212</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Dark">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>85</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Mid">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>113</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Text">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>85</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="BrightText">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>255</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="ButtonText">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>85</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Base">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>170</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Window">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>170</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Shadow">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>0</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="AlternateBase">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>170</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="ToolTipBase">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>220</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="ToolTipText">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>0</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="PlaceholderText">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="128">
+                      <red>0</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </disabled>
+                 </palette>
+                </property>
+                <property name="font">
+                 <font>
+                  <weight>75</weight>
+                  <bold>true</bold>
+                  <strikeout>false</strikeout>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Reset Settings</string>
+                </property>
+                <property name="default">
+                 <bool>false</bool>
+                </property>
+                <property name="flat">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/ui/dsettings.ui
+++ b/ui/dsettings.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tabApp">
       <attribute name="title">
@@ -56,7 +56,7 @@
                   </widget>
                  </item>
                  <item>
-                  <widget class="QComboBox" name="cb_startupBehavior">
+                  <widget class="QComboBox" name="cb_startupBehaviour">
                    <item>
                     <property name="text">
                      <string>No</string>


### PR DESCRIPTION
* DSettings
	* Added the Settings dialog `DSettings`. It's ready!

* Preferences
	* Added all new preferences in `Preferences`

* DSettings saves
	* Added more conditions in `Preferences` for the setters
	* Added link between `DSettings` and `Preferences`

* Generic Preferences & connect everywhere
	* Added few fonctions in `Preferences` for each "*attribute*" for more genericity.
	* Connect `Preferences` to `MainWindows` and `DSettings`.

* Fixed crash
	* Fixed the crash: It was not from the menu but from `Preferences` line 125: `if (ok && 1000 <= isRefreshTimeoutValid(refreshTimeout))` is completly false, by removing `1000 <= ` it works!!
	* Added a default function for `firstLaunch`

* Crash fix
	* Crashprove dsettings by disconnecting and connecting again the link between the widget and preferences when updated.

* Run at startup
	* Added a function in `Preferences` to run the app at startup (or not!)

* System tray
	* Fixed #3
	* Added System Tray support